### PR TITLE
use metadata to generate table of contents

### DIFF
--- a/_templates/api.html
+++ b/_templates/api.html
@@ -4,6 +4,20 @@ layout: api_docs
 ---
 
 {{ page.html }}
+
+<h2><a id='#methods'></a><a href='#methods'>{{page.title}} Methods: </a></h2>
+<ul class="api-table-of-contents">
+{% for s in page.sub %}
+  {% if s.meta %}
+    <li>
+      <a href="#{{ s.id }}">
+        <span class='batman-class'>{{page.title}}</span>{% if s.meta.level == 'class' %}.{% else %}::{% endif %}{{ s.title }}{% if s.meta.params %}{% if s.meta.type == 'property' %}<span class="params">{{ s.meta.params }}</span>{% else %}<span class="params">({{ s.meta.params }})</span>  {% endif %}{% endif %}{% if s.meta.returnType %}<span class="return-type"> : {{ s.meta.returnType }}</span>{% endif %}</span>
+      </a>
+    </li>
+  {% endif %}
+{% endfor %}
+</ul>
+
 <ul class="api-list">
 {% for s in page.sub %}
   <li class="api-list-item">


### PR DESCRIPTION
If you guys are into it, I think a little table of contents on each file would be really nice. As the files grow, it's harder to scan the file for what you want. The autocomplete is great if you already know what you're looking for, but tough for getting the big picture. 

I added a bit to `_templates/api.html` that uses the YAML front matter to generate a table of contents like this one, where each entry links to the docs for that function:

![screen shot 2014-02-12 at 4 59 59 pm](https://f.cloud.github.com/assets/2231765/2155690/3fddb8fc-944a-11e3-9b64-332eca835231.png)

**Issues:**
- needs styles :)
- some files don't have metadata yet -- would need to add it
